### PR TITLE
feat: Add LeadConnector chat widget to all pages

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -16,6 +16,24 @@ export default function Home() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  // Load chat widget
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'https://widgets.leadconnectorhq.com/loader.js';
+    script.setAttribute('data-resources-url', 'https://widgets.leadconnectorhq.com/chat-widget/loader.js');
+    script.setAttribute('data-widget-id', '68d4bd7eb5b5024705dd0eaa');
+    script.async = true;
+    
+    document.body.appendChild(script);
+    
+    return () => {
+      // Cleanup script when component unmounts
+      if (document.body.contains(script)) {
+        document.body.removeChild(script);
+      }
+    };
+  }, []);
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}

--- a/src/components/WhyUs.tsx
+++ b/src/components/WhyUs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { 
   ArrowLeft, 
@@ -16,6 +16,24 @@ import {
 } from 'lucide-react';
 
 export default function WhyUs() {
+  // Load chat widget
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'https://widgets.leadconnectorhq.com/loader.js';
+    script.setAttribute('data-resources-url', 'https://widgets.leadconnectorhq.com/chat-widget/loader.js');
+    script.setAttribute('data-widget-id', '68d4bd7eb5b5024705dd0eaa');
+    script.async = true;
+    
+    document.body.appendChild(script);
+    
+    return () => {
+      // Cleanup script when component unmounts
+      if (document.body.contains(script)) {
+        document.body.removeChild(script);
+      }
+    };
+  }, []);
+
   return (
     <div className="min-h-screen bg-white">
       {/* Header */}


### PR DESCRIPTION
- Integrate LeadConnector HQ chat widget with ID 68d4bd7eb5b5024705dd0eaa
- Add chat widget script loading via useEffect hook in both Home and WhyUs components
- Implement proper script cleanup on component unmount to prevent memory leaks
- Chat widget loads asynchronously for optimal page performance
- Widget appears on both homepage and Why Us page for consistent customer support access
- Enable real-time customer engagement and lead capture across entire site

The chat widget provides instant customer support and helps capture leads from visitors browsing either the main landing page or the detailed Why Us content.